### PR TITLE
feat(version): upgrade clouddriver version to latest

### DIFF
--- a/.github/workflows/latestClouddriver.yml
+++ b/.github/workflows/latestClouddriver.yml
@@ -1,0 +1,51 @@
+name: Latest Clouddriver
+
+on:
+  schedule:
+    - cron:  '*/15 * * * *'
+
+jobs:
+  test_latest:
+    name: Test Latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: get dependency name to update
+        id: dependency_name
+        run: |
+          echo ::set-output name=dependency::clouddriver
+      - name: get current version
+        id: get_current
+        run: |
+          echo ::set-output name=version::$(cat gradle.properties | grep "${{ steps.dependency_name.outputs.dependency }}Version" | cut -d'=' -f2)
+      - name: get latest release version
+        id: get_latest_release
+        run: |
+          echo ::set-output name=version::$(curl -XGET -u "${{ secrets.USERNAME }}:${{ secrets.TOKEN }}" https://api.github.com/repos/spinnaker/${{ steps.dependency_name.outputs.dependency }}/releases/latest | jq '.tag_name' | cut -d 'v' -f2 | cut -d '"' -f1)
+      - name: get desired version
+        id: get_desired
+        run: |
+          echo -e "${{ steps.get_current.outputs.version }}\n${{ steps.get_latest_release.outputs.version }}" > updateVersions.txt
+          echo ::set-output name=version::$(sort -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4 -g -r updateVersions.txt | head -n 1)
+      - name: test desired version
+        if: steps.get_current.outputs.version != steps.get_desired.outputs.version
+        run: |
+          sed -i -e 's/${{ steps.dependency_name.outputs.dependency }}Version=${{ steps.get_current.outputs.version }}/${{ steps.dependency_name.outputs.dependency }}Version=${{ steps.get_desired.outputs.version }}/g' gradle.properties
+          ./gradlew test
+      - name: notify build failure
+        if: failure()
+        run: |
+          curl -XPOST -u "${{ secrets.USERNAME }}:${{ secrets.TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/armory-plugins/armory-crdcheck-plugin-releases/dispatches --data "{\"event_type\": \"onPluginDepUpdateFailure\", \"client_payload\": {\"workflow\": \"${GITHUB_WORKFLOW}\", \"repo\": \"${GITHUB_REPOSITORY}\", \"dependency\": \"${{ steps.dependency_name.outputs.dependency }}\", \"version\": \"${{ steps.get_desired.outputs.version }}\"}}"
+      - name: commit gradle properties
+        if: (steps.get_current.outputs.version != steps.get_desired.outputs.version) && success()
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add gradle.properties
+          git commit -m "update ${{ steps.dependency_name.outputs.dependency }} to ${{ steps.get_desired.outputs.version }}"
+      - name: push changes
+        if: (steps.get_current.outputs.version != steps.get_desired.outputs.version) && success()
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/latestKork.yml
+++ b/.github/workflows/latestKork.yml
@@ -1,0 +1,51 @@
+name: Latest Kork
+
+on:
+  schedule:
+    - cron:  '*/15 * * * *'
+
+jobs:
+  test_latest:
+    name: Test Latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: get dependency name to update
+        id: dependency_name
+        run: |
+          echo ::set-output name=dependency::kork
+      - name: get current version
+        id: get_current
+        run: |
+          echo ::set-output name=version::$(cat gradle.properties | grep "${{ steps.dependency_name.outputs.dependency }}Version" | cut -d'=' -f2)
+      - name: get latest release version
+        id: get_latest_release
+        run: |
+          echo ::set-output name=version::$(curl -XGET -u "${{ secrets.USERNAME }}:${{ secrets.TOKEN }}" https://api.github.com/repos/spinnaker/${{ steps.dependency_name.outputs.dependency }}/releases/latest | jq '.tag_name' | cut -d 'v' -f2 | cut -d '"' -f1)
+      - name: get desired version
+        id: get_desired
+        run: |
+          echo -e "${{ steps.get_current.outputs.version }}\n${{ steps.get_latest_release.outputs.version }}" > updateVersions.txt
+          echo ::set-output name=version::$(sort -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4 -g -r updateVersions.txt | head -n 1)
+      - name: test desired version
+        if: steps.get_current.outputs.version != steps.get_desired.outputs.version
+        run: |
+          sed -i -e 's/${{ steps.dependency_name.outputs.dependency }}Version=${{ steps.get_current.outputs.version }}/${{ steps.dependency_name.outputs.dependency }}Version=${{ steps.get_desired.outputs.version }}/g' gradle.properties
+          ./gradlew test
+      - name: notify build failure
+        if: failure()
+        run: |
+          curl -XPOST -u "${{ secrets.USERNAME }}:${{ secrets.TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/armory-plugins/armory-crdcheck-plugin-releases/dispatches --data "{\"event_type\": \"onPluginDepUpdateFailure\", \"client_payload\": {\"workflow\": \"${GITHUB_WORKFLOW}\", \"repo\": \"${GITHUB_REPOSITORY}\", \"dependency\": \"${{ steps.dependency_name.outputs.dependency }}\", \"version\": \"${{ steps.get_desired.outputs.version }}\"}}"
+      - name: commit gradle properties
+        if: (steps.get_current.outputs.version != steps.get_desired.outputs.version) && success()
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add gradle.properties
+          git commit -m "update ${{ steps.dependency_name.outputs.dependency }} to ${{ steps.get_desired.outputs.version }}"
+      - name: push changes
+        if: (steps.get_current.outputs.version != steps.get_desired.outputs.version) && success()
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin helps to determinate if a CRD is stable or not.
 | Plugin  | Spinnaker Platform | Armory Spinnaker Platform
 |:----------- | :--------- | :---------
 | 0.0.17  |  1.19.x & 1.20.x | 2.20.x
-| 1.0.0  |  1.21.x | 2.21.x
+| 0.1.0  |  1.21.x | 2.21.x
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ This plugin helps to determinate if a CRD is stable or not.
 
 # Version Compatibility
  
-| Plugin  | Spinnaker Platform | Armory Spinnaker
+| Plugin  | Spinnaker Platform | Armory Spinnaker Platform
 |:----------- | :--------- | :---------
 | 0.0.17  |  1.19.x & 1.20.x | 2.20.x
+| 1.0.0  |  1.21.x | 2.21.x
 
 # Usage
 

--- a/crdcheck-clouddriver/crdcheck-clouddriver.gradle
+++ b/crdcheck-clouddriver/crdcheck-clouddriver.gradle
@@ -31,13 +31,11 @@ dependencies {
     compileOnly(group: "com.netflix.spinnaker.clouddriver", name: "clouddriver-core", version: "${clouddriverVersion}")
     compileOnly(group: "com.netflix.spinnaker.clouddriver", name: "cats-core", version: "${clouddriverVersion}")
     compileOnly(group: "com.netflix.spinnaker.clouddriver", name: "clouddriver-kubernetes", version: "${clouddriverVersion}")
-    compileOnly(group: "com.netflix.spinnaker.clouddriver", name: "clouddriver-kubernetes-v2", version: "${clouddriverVersion}")
     compileOnly(group: "com.netflix.spectator", name: "spectator-api", version: "0.75.0")
     compileOnly(group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.9.8')
 
     testImplementation(group: "com.netflix.spinnaker.clouddriver", name: "clouddriver-core", version: "${clouddriverVersion}")
     testImplementation(group: "com.netflix.spinnaker.clouddriver", name: "clouddriver-kubernetes", version: "${clouddriverVersion}")
-    testImplementation(group: "com.netflix.spinnaker.clouddriver", name: "clouddriver-kubernetes-v2", version: "${clouddriverVersion}")
     testImplementation(group: "com.netflix.spinnaker.clouddriver", name: "clouddriver-security", version: "${clouddriverVersion}")
     testImplementation(group: "com.netflix.spinnaker.kork", name: "kork-plugins", version: "${korkVersion}")
     testImplementation(group: "com.netflix.spectator", name: "spectator-api", version: "0.75.0")

--- a/crdcheck-clouddriver/src/main/kotlin/io/armory/plugin/kubernetes/handlers/OperatorCRDHandler.kt
+++ b/crdcheck-clouddriver/src/main/kotlin/io/armory/plugin/kubernetes/handlers/OperatorCRDHandler.kt
@@ -18,14 +18,14 @@ package io.armory.plugin.kubernetes.handlers
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.CustomKubernetesCachingAgentFactory
+import com.netflix.spinnaker.clouddriver.kubernetes.caching.agent.KubernetesV2CachingAgentFactory
 import com.netflix.spinnaker.clouddriver.kubernetes.description.SpinnakerKind
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.CustomKubernetesCachingAgentFactory
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.caching.agent.KubernetesV2CachingAgentFactory
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiGroup
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.op.handler.KubernetesHandler
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiGroup
+import com.netflix.spinnaker.clouddriver.kubernetes.op.handler.KubernetesHandler
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest
+import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest
 import org.slf4j.LoggerFactory
 
 class OperatorCRDHandler(): KubernetesHandler() {

--- a/crdcheck-clouddriver/src/test/kotlin/io/armory/plugin/kubernetes/handlers/OperatorCRDHandlerTest.kt
+++ b/crdcheck-clouddriver/src/test/kotlin/io/armory/plugin/kubernetes/handlers/OperatorCRDHandlerTest.kt
@@ -1,17 +1,32 @@
-package io.armory.plugin.kubernetes
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.armory.plugin.kubernetes.handlers
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiGroup
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesApiVersion
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesKind
+import com.netflix.spinnaker.clouddriver.kubernetes.description.manifest.KubernetesManifest
+import com.netflix.spinnaker.clouddriver.kubernetes.model.Manifest
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiGroup
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesApiVersion
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesKind
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifest
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.model.Manifest
-import com.netflix.spinnaker.clouddriver.kubernetes.v2.security.KubernetesV2Credentials
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesV2Credentials
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.armory.plugin.kubernetes.handlers.OperatorCRDHandler
 import io.mockk.mockk
 import strikt.api.expectCatching
 import strikt.api.expectThat
@@ -29,20 +44,20 @@ class OperatorCRDHandlerTest: JUnit5Minutests {
         val stableManifest = OperatorCRDStatus(
                 1,
                 "test-url",
-                Config(LastDeployed("test-hash", "test-date"),LastDeployed("test-hash", "test-date")),
+                Config(LastDeployed("test-hash", "test-date"), LastDeployed("test-hash", "test-date")),
                 1,
-                listOf(Service("test-image", "test-name", 5,5)),
+                listOf(Service("test-image", "test-name", 5, 5)),
                 "OK",
                 "test-uiurl",
                 "test-version"
-                )
+        )
 
         val unstableManifest = OperatorCRDStatus(
                 1,
                 "test-url",
-                Config(LastDeployed("test-hash", "test-date"),LastDeployed("test-hash", "test-date")),
+                Config(LastDeployed("test-hash", "test-date"), LastDeployed("test-hash", "test-date")),
                 1,
-                listOf(Service("test-image", "test-name", 5,5)),
+                listOf(Service("test-image", "test-name", 5, 5)),
                 "ERROR",
                 "test-uiurl",
                 "test-version"
@@ -51,9 +66,9 @@ class OperatorCRDHandlerTest: JUnit5Minutests {
         val unstableManifestWithoutAllReplicas = OperatorCRDStatus(
                 1,
                 "test-url",
-                Config(LastDeployed("test-hash", "test-date"),LastDeployed("test-hash", "test-date")),
+                Config(LastDeployed("test-hash", "test-date"), LastDeployed("test-hash", "test-date")),
                 1,
-                listOf(Service("test-image", "test-name", 2,5)),
+                listOf(Service("test-image", "test-name", 2, 5)),
                 "OK",
                 "test-uiurl",
                 "test-version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ spinnakerGradleVersion=8.0.4
 pf4jVersion=3.2.0
 korkVersion=7.43.6
 
-clouddriverVersion=5.57.0
+clouddriverVersion=5.62.0
 
 kotlinVersion=1.3.50


### PR DESCRIPTION
This Pr is about upgrade `clouddriver` version to latest (`5.62.0`) and made the necessary changes to use the correct package.

Also includes the github workflows to have the latest Clouddriver and Kork on the plugin.